### PR TITLE
[fix] 네이버 지도 하단 텍스트가 bottom nav 위로 올라오는 현상 해결

### DIFF
--- a/src/shared/components/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation.tsx
@@ -26,7 +26,7 @@ export function BottomNavigation() {
   const { pathname } = useLocation();
 
   return (
-    <div className="max-w-mobile fixed right-0 bottom-0 left-0 z-50 mx-auto bg-white pt-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] shadow-sm">
+    <div className="max-w-mobile fixed right-0 bottom-0 left-0 z-999 mx-auto bg-white pt-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] shadow-sm">
       <div className="flex text-xs">
         {ROUTES.map((route) => (
           <Link


### PR DESCRIPTION
## 작업내용

<!--
해당 Pull Request에서 진행했던 내용들을 작성합니다.

ex)
- [x] 카카오 로그인
- [x] 구글 로그인
 -->

네이버 지도 하단 텍스트가 bottom nav 위로 올라오는 현상 해결을 해결했습니다.

## 스크린샷(선택)

<!--
구현한 내용에 대한 스크린샷을 첨부합니다.
 -->

## 메모(선택)

 <!--
해당 Pull Request에 대한 메모를 작성합니다.

ex)
- 추후 디벨롭 예정입니다.
 -->

## 연관 이슈

<!--
진행했던 이슈의 번호를 입력합니다.

ex)
resolved #1
-->

resolved #19 
