### PR TITLE
[feat] 전철 탭에서 사용할 API 구현

### DIFF
--- a/src/domain/subway/api/keys/index.ts
+++ b/src/domain/subway/api/keys/index.ts
@@ -2,7 +2,5 @@ export const subwayKeys = {
   all: ["subway"] as const,
   list: () => [...subwayKeys.all, "list"] as const,
   detail: (stationName: string) => [...subwayKeys.all, "detail", stationName] as const,
-  create: () => [...subwayKeys.all, "create"] as const,
-  update: () => [...subwayKeys.all, "update"] as const,
-  delete: () => [...subwayKeys.all, "delete"] as const,
+  arrival: (stationName: string) => [...subwayKeys.all, "arrival", stationName] as const,
 };

--- a/src/domain/subway/api/models/index.ts
+++ b/src/domain/subway/api/models/index.ts
@@ -64,3 +64,15 @@ export const GetSubwayHomePreviewResponseSchema = z.object({
 });
 
 export type GetSubwayHomePreviewResponse = z.infer<typeof GetSubwayHomePreviewResponseSchema>;
+
+export interface GetSubwayArrivalTrainRow {
+  toward: string;
+  location: string;
+  subwwayType: string;
+}
+
+export interface GetSubwayArrivalResponse {
+  station: string;
+  uphill: GetSubwayArrivalTrainRow[];
+  downward: GetSubwayArrivalTrainRow[];
+}

--- a/src/domain/subway/api/queries/index.ts
+++ b/src/domain/subway/api/queries/index.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { subwayKeys } from "#/domain/subway/api/keys";
-import { getSubwayHomePreview } from "#/domain/subway/api/services";
+import { getSubwayArrival, getSubwayHomePreview } from "#/domain/subway/api/services";
 import { ms } from "#/shared/utils";
 
 export const SUBWAY_QUERIES = {
@@ -9,6 +9,12 @@ export const SUBWAY_QUERIES = {
     queryOptions({
       queryKey: subwayKeys.detail(stationName),
       queryFn: () => getSubwayHomePreview(stationName),
+      refetchInterval: ms.seconds(25),
+    }),
+  GetSubwayArrival: (stationName: string) =>
+    queryOptions({
+      queryKey: subwayKeys.arrival(stationName),
+      queryFn: () => getSubwayArrival(stationName),
       refetchInterval: ms.seconds(25),
     }),
 };

--- a/src/domain/subway/api/services/index.ts
+++ b/src/domain/subway/api/services/index.ts
@@ -3,6 +3,7 @@ import type {
   GetSubwayHomePreviewResponse,
 } from "#/domain/subway/api/models";
 import { api } from "#/shared/api";
+import { apiV2 } from "#/shared/api/instance";
 
 export const getSubwayHomePreview = async (stationName: string) => {
   return api<GetSubwayHomePreviewResponse>(`subway/preview`, {
@@ -11,7 +12,7 @@ export const getSubwayHomePreview = async (stationName: string) => {
 };
 
 export const getSubwayArrival = async (stationName: string) => {
-  return api<GetSubwayArrivalResponse>(`subway/arrival`, {
+  return apiV2<GetSubwayArrivalResponse>(`subway/arrival`, {
     searchParams: { stationName },
-  });
+  }).json();
 };

--- a/src/domain/subway/api/services/index.ts
+++ b/src/domain/subway/api/services/index.ts
@@ -1,8 +1,17 @@
-import type { GetSubwayHomePreviewResponse } from "#/domain/subway/api/models";
+import type {
+  GetSubwayArrivalResponse,
+  GetSubwayHomePreviewResponse,
+} from "#/domain/subway/api/models";
 import { api } from "#/shared/api";
 
 export const getSubwayHomePreview = async (stationName: string) => {
   return api<GetSubwayHomePreviewResponse>(`subway/preview`, {
+    searchParams: { stationName },
+  });
+};
+
+export const getSubwayArrival = async (stationName: string) => {
+  return api<GetSubwayArrivalResponse>(`subway/arrival`, {
     searchParams: { stationName },
   });
 };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SubwayRouteImport } from './routes/subway'
 import { Route as ShuttleRouteImport } from './routes/shuttle'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiSubwayPreviewRouteImport } from './routes/api/subway/preview'
+import { Route as ApiSubwayArrivalRouteImport } from './routes/api/subway/arrival'
 import { Route as ApiShuttleTimeTableRulesRouteImport } from './routes/api/shuttle/time-table-rules'
 import { Route as ApiShuttlePatternsRouteImport } from './routes/api/shuttle/patterns'
 import { Route as ApiShuttleV2TimesRouteImport } from './routes/api/shuttle/v2/times'
@@ -36,6 +37,11 @@ const IndexRoute = IndexRouteImport.update({
 const ApiSubwayPreviewRoute = ApiSubwayPreviewRouteImport.update({
   id: '/api/subway/preview',
   path: '/api/subway/preview',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSubwayArrivalRoute = ApiSubwayArrivalRouteImport.update({
+  id: '/api/subway/arrival',
+  path: '/api/subway/arrival',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiShuttleTimeTableRulesRoute =
@@ -66,6 +72,7 @@ export interface FileRoutesByFullPath {
   '/subway': typeof SubwayRoute
   '/api/shuttle/patterns': typeof ApiShuttlePatternsRoute
   '/api/shuttle/time-table-rules': typeof ApiShuttleTimeTableRulesRoute
+  '/api/subway/arrival': typeof ApiSubwayArrivalRoute
   '/api/subway/preview': typeof ApiSubwayPreviewRoute
   '/api/shuttle/v2/stops': typeof ApiShuttleV2StopsRoute
   '/api/shuttle/v2/times': typeof ApiShuttleV2TimesRoute
@@ -76,6 +83,7 @@ export interface FileRoutesByTo {
   '/subway': typeof SubwayRoute
   '/api/shuttle/patterns': typeof ApiShuttlePatternsRoute
   '/api/shuttle/time-table-rules': typeof ApiShuttleTimeTableRulesRoute
+  '/api/subway/arrival': typeof ApiSubwayArrivalRoute
   '/api/subway/preview': typeof ApiSubwayPreviewRoute
   '/api/shuttle/v2/stops': typeof ApiShuttleV2StopsRoute
   '/api/shuttle/v2/times': typeof ApiShuttleV2TimesRoute
@@ -87,6 +95,7 @@ export interface FileRoutesById {
   '/subway': typeof SubwayRoute
   '/api/shuttle/patterns': typeof ApiShuttlePatternsRoute
   '/api/shuttle/time-table-rules': typeof ApiShuttleTimeTableRulesRoute
+  '/api/subway/arrival': typeof ApiSubwayArrivalRoute
   '/api/subway/preview': typeof ApiSubwayPreviewRoute
   '/api/shuttle/v2/stops': typeof ApiShuttleV2StopsRoute
   '/api/shuttle/v2/times': typeof ApiShuttleV2TimesRoute
@@ -99,6 +108,7 @@ export interface FileRouteTypes {
     | '/subway'
     | '/api/shuttle/patterns'
     | '/api/shuttle/time-table-rules'
+    | '/api/subway/arrival'
     | '/api/subway/preview'
     | '/api/shuttle/v2/stops'
     | '/api/shuttle/v2/times'
@@ -109,6 +119,7 @@ export interface FileRouteTypes {
     | '/subway'
     | '/api/shuttle/patterns'
     | '/api/shuttle/time-table-rules'
+    | '/api/subway/arrival'
     | '/api/subway/preview'
     | '/api/shuttle/v2/stops'
     | '/api/shuttle/v2/times'
@@ -119,6 +130,7 @@ export interface FileRouteTypes {
     | '/subway'
     | '/api/shuttle/patterns'
     | '/api/shuttle/time-table-rules'
+    | '/api/subway/arrival'
     | '/api/subway/preview'
     | '/api/shuttle/v2/stops'
     | '/api/shuttle/v2/times'
@@ -130,6 +142,7 @@ export interface RootRouteChildren {
   SubwayRoute: typeof SubwayRoute
   ApiShuttlePatternsRoute: typeof ApiShuttlePatternsRoute
   ApiShuttleTimeTableRulesRoute: typeof ApiShuttleTimeTableRulesRoute
+  ApiSubwayArrivalRoute: typeof ApiSubwayArrivalRoute
   ApiSubwayPreviewRoute: typeof ApiSubwayPreviewRoute
   ApiShuttleV2StopsRoute: typeof ApiShuttleV2StopsRoute
   ApiShuttleV2TimesRoute: typeof ApiShuttleV2TimesRoute
@@ -163,6 +176,13 @@ declare module '@tanstack/react-router' {
       path: '/api/subway/preview'
       fullPath: '/api/subway/preview'
       preLoaderRoute: typeof ApiSubwayPreviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/subway/arrival': {
+      id: '/api/subway/arrival'
+      path: '/api/subway/arrival'
+      fullPath: '/api/subway/arrival'
+      preLoaderRoute: typeof ApiSubwayArrivalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/shuttle/time-table-rules': {
@@ -202,6 +222,7 @@ const rootRouteChildren: RootRouteChildren = {
   SubwayRoute: SubwayRoute,
   ApiShuttlePatternsRoute: ApiShuttlePatternsRoute,
   ApiShuttleTimeTableRulesRoute: ApiShuttleTimeTableRulesRoute,
+  ApiSubwayArrivalRoute: ApiSubwayArrivalRoute,
   ApiSubwayPreviewRoute: ApiSubwayPreviewRoute,
   ApiShuttleV2StopsRoute: ApiShuttleV2StopsRoute,
   ApiShuttleV2TimesRoute: ApiShuttleV2TimesRoute,

--- a/src/routes/api/subway/arrival.ts
+++ b/src/routes/api/subway/arrival.ts
@@ -1,0 +1,172 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import ky from "ky";
+
+import type {
+  GetSubwayArrivalResponse,
+  GetSubwayArrivalTrainRow,
+  RealtimeArrivalItem,
+} from "#/domain/subway/api/models";
+import { SeoulRealtimeStationArrivalApiResponseSchema } from "#/domain/subway/api/models";
+import { TtlMemoryCache } from "#/server/ttl-memory-cache";
+import { withErrorResponse, withErrorResponseFromUnknown, withSuccessResponse } from "#/shared/api";
+import { ms } from "#/shared/utils";
+
+const subwayArrivalCache = new TtlMemoryCache(15_000);
+
+const SEOUL_REALTIME_ARRIVAL_START_INDEX = 1;
+const SEOUL_REALTIME_ARRIVAL_END_INDEX = 40;
+const SQUARE_BRACKET_PATTERN = /\[([^\]]*)\]/g;
+const NTH_PREV_STATION_HEAD_PATTERN = /^(\d+)번째\s*전역/;
+
+const DEFAULT_LIMIT_PER_DIRECTION = 3;
+const MAX_LIMIT_PER_DIRECTION = 40;
+const MIN_LIMIT_PER_DIRECTION = 1;
+
+const subwayApiKey = process.env.SUBWAY_API_KEY ?? "";
+
+function normalizePreviewArrivalMessage(rawMessage: string): string {
+  const trimmed = rawMessage.replace(SQUARE_BRACKET_PATTERN, "$1").trim();
+  const nthPrevStationMatch = trimmed.match(NTH_PREV_STATION_HEAD_PATTERN);
+  if (nthPrevStationMatch?.[1]) {
+    return `${nthPrevStationMatch[1]}번째 전역`;
+  }
+  return trimmed;
+}
+
+function buildSeoulRealtimeStationArrivalUrl(input: { apiKey: string; stationName: string }) {
+  const encodedStationName = encodeURIComponent(input.stationName);
+  return `http://swopenapi.seoul.go.kr/api/subway/${input.apiKey}/json/realtimeStationArrival/${SEOUL_REALTIME_ARRIVAL_START_INDEX}/${SEOUL_REALTIME_ARRIVAL_END_INDEX}/${encodedStationName}`;
+}
+
+function parseLimitPerDirection(raw: string | null): number {
+  if (raw === null || raw.trim().length === 0) {
+    return DEFAULT_LIMIT_PER_DIRECTION;
+  }
+  const parsed: number = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) {
+    return DEFAULT_LIMIT_PER_DIRECTION;
+  }
+  return Math.min(MAX_LIMIT_PER_DIRECTION, Math.max(MIN_LIMIT_PER_DIRECTION, parsed));
+}
+
+function isUphillDirection(updnLine: string): boolean {
+  const direction = updnLine.trim();
+  return direction === "상행" || direction === "내선";
+}
+
+function isDownwardDirection(updnLine: string): boolean {
+  const direction = updnLine.trim();
+  return direction === "하행" || direction === "외선";
+}
+
+function resolveTowardLabel(destinationStationRaw: string): string {
+  const trimmed: string = destinationStationRaw.trim();
+  if (trimmed.length === 0) {
+    return "—";
+  }
+  return trimmed.endsWith("행") ? trimmed : `${trimmed}행`;
+}
+
+function resolveLocationText(arrivalMessageRaw: string): string {
+  const trimmed: string = arrivalMessageRaw.trim();
+  return trimmed.length > 0 ? trimmed : "도착 정보 없음";
+}
+
+function mapRealtimeItemToTrainRow(train: RealtimeArrivalItem): GetSubwayArrivalTrainRow {
+  return {
+    toward: resolveTowardLabel(train.bstatnNm),
+    location: resolveLocationText(train.arvlMsg2),
+    subwwayType: train.btrainSttus,
+  };
+}
+
+/** 서울 API가 주는 순서를 유지하며 상행·내선 / 하행·외선으로 각각 최대 `limitPerDirection`개만 수집합니다. */
+function buildUphillDownwardArrays(input: {
+  arrivals: RealtimeArrivalItem[];
+  limitPerDirection: number;
+}) {
+  const uphill: GetSubwayArrivalTrainRow[] = [];
+  const downward: GetSubwayArrivalTrainRow[] = [];
+
+  for (const train of input.arrivals) {
+    if (isUphillDirection(train.updnLine) && uphill.length < input.limitPerDirection) {
+      uphill.push(mapRealtimeItemToTrainRow(train));
+    } else if (isDownwardDirection(train.updnLine) && downward.length < input.limitPerDirection) {
+      downward.push(mapRealtimeItemToTrainRow(train));
+    }
+  }
+
+  return { uphill, downward };
+}
+
+export const Route = createFileRoute("/api/subway/arrival")({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        try {
+          const requestUrl = new URL(request.url);
+          const stationNameRaw = requestUrl.searchParams.get("stationName");
+          const station = (stationNameRaw ?? "").trim();
+          if (station.length === 0) {
+            return withErrorResponse("stationName 쿼리가 필요합니다.", 400);
+          }
+
+          const limitRaw = requestUrl.searchParams.get("limitPerDirection");
+          const limitPerDirection = parseLimitPerDirection(limitRaw);
+
+          const cacheKey = `subway:arrival:v3:${station}:limit:${String(limitPerDirection)}`;
+          const cached = subwayArrivalCache.get<GetSubwayArrivalResponse>(cacheKey);
+          if (cached) {
+            return withSuccessResponse(cached);
+          }
+
+          const seoulUrl = buildSeoulRealtimeStationArrivalUrl({
+            apiKey: subwayApiKey,
+            stationName: station,
+          });
+
+          const raw = await ky
+            .get(seoulUrl, { timeout: ms.seconds(15), retry: { limit: 0 } })
+            .json();
+          const parsed = SeoulRealtimeStationArrivalApiResponseSchema.safeParse(raw);
+          if (!parsed.success) {
+            throw withErrorResponse("서울시 지하철 도착 API 응답 형식이 예상과 다릅니다.", 500);
+          }
+
+          const errorCode = parsed.data.errorMessage?.code;
+          if (errorCode !== undefined && errorCode !== "" && errorCode !== "INFO-000") {
+            const errorMessage =
+              parsed.data.errorMessage?.message ?? "서울시 지하철 도착 API 오류가 발생했습니다.";
+            throw withErrorResponse(errorMessage, 500);
+          }
+
+          const arrivals = (parsed.data.realtimeArrivalList ?? []).map((arrival) => ({
+            subwayId: arrival.subwayId ?? "",
+            updnLine: arrival.updnLine ?? "",
+            trainLineNm: arrival.trainLineNm ?? "",
+            bstatnNm: arrival.bstatnNm ?? "",
+            arvlMsg2: normalizePreviewArrivalMessage(arrival.arvlMsg2 ?? ""),
+            btrainSttus: arrival.btrainSttus ?? "",
+          }));
+
+          const { uphill, downward } = buildUphillDownwardArrays({
+            arrivals,
+            limitPerDirection,
+          });
+
+          const payload: GetSubwayArrivalResponse = {
+            station,
+            uphill,
+            downward,
+          };
+
+          subwayArrivalCache.set(cacheKey, payload);
+          return withSuccessResponse(payload);
+        } catch (error: unknown) {
+          return withErrorResponseFromUnknown(error);
+        }
+      },
+    },
+  },
+});

--- a/src/routes/api/subway/arrival.ts
+++ b/src/routes/api/subway/arrival.ts
@@ -20,8 +20,6 @@ const SQUARE_BRACKET_PATTERN = /\[([^\]]*)\]/g;
 const NTH_PREV_STATION_HEAD_PATTERN = /^(\d+)번째\s*전역/;
 
 const DEFAULT_LIMIT_PER_DIRECTION = 3;
-const MAX_LIMIT_PER_DIRECTION = 40;
-const MIN_LIMIT_PER_DIRECTION = 1;
 
 const subwayApiKey = process.env.SUBWAY_API_KEY ?? "";
 
@@ -37,17 +35,6 @@ function normalizePreviewArrivalMessage(rawMessage: string): string {
 function buildSeoulRealtimeStationArrivalUrl(input: { apiKey: string; stationName: string }) {
   const encodedStationName = encodeURIComponent(input.stationName);
   return `http://swopenapi.seoul.go.kr/api/subway/${input.apiKey}/json/realtimeStationArrival/${SEOUL_REALTIME_ARRIVAL_START_INDEX}/${SEOUL_REALTIME_ARRIVAL_END_INDEX}/${encodedStationName}`;
-}
-
-function parseLimitPerDirection(raw: string | null): number {
-  if (raw === null || raw.trim().length === 0) {
-    return DEFAULT_LIMIT_PER_DIRECTION;
-  }
-  const parsed: number = Number.parseInt(raw, 10);
-  if (Number.isNaN(parsed)) {
-    return DEFAULT_LIMIT_PER_DIRECTION;
-  }
-  return Math.min(MAX_LIMIT_PER_DIRECTION, Math.max(MIN_LIMIT_PER_DIRECTION, parsed));
 }
 
 function isUphillDirection(updnLine: string): boolean {
@@ -82,17 +69,17 @@ function mapRealtimeItemToTrainRow(train: RealtimeArrivalItem): GetSubwayArrival
 }
 
 /** 서울 API가 주는 순서를 유지하며 상행·내선 / 하행·외선으로 각각 최대 `limitPerDirection`개만 수집합니다. */
-function buildUphillDownwardArrays(input: {
-  arrivals: RealtimeArrivalItem[];
-  limitPerDirection: number;
-}) {
+function buildUphillDownwardArrays(input: { arrivals: RealtimeArrivalItem[] }) {
   const uphill: GetSubwayArrivalTrainRow[] = [];
   const downward: GetSubwayArrivalTrainRow[] = [];
 
   for (const train of input.arrivals) {
-    if (isUphillDirection(train.updnLine) && uphill.length < input.limitPerDirection) {
+    if (isUphillDirection(train.updnLine) && uphill.length < DEFAULT_LIMIT_PER_DIRECTION) {
       uphill.push(mapRealtimeItemToTrainRow(train));
-    } else if (isDownwardDirection(train.updnLine) && downward.length < input.limitPerDirection) {
+    } else if (
+      isDownwardDirection(train.updnLine) &&
+      downward.length < DEFAULT_LIMIT_PER_DIRECTION
+    ) {
       downward.push(mapRealtimeItemToTrainRow(train));
     }
   }
@@ -112,10 +99,7 @@ export const Route = createFileRoute("/api/subway/arrival")({
             return withErrorResponse("stationName 쿼리가 필요합니다.", 400);
           }
 
-          const limitRaw = requestUrl.searchParams.get("limitPerDirection");
-          const limitPerDirection = parseLimitPerDirection(limitRaw);
-
-          const cacheKey = `subway:arrival:v3:${station}:limit:${String(limitPerDirection)}`;
+          const cacheKey = `subway:arrival:v3:${station}`;
           const cached = subwayArrivalCache.get<GetSubwayArrivalResponse>(cacheKey);
           if (cached) {
             return withSuccessResponse(cached);
@@ -150,10 +134,7 @@ export const Route = createFileRoute("/api/subway/arrival")({
             btrainSttus: arrival.btrainSttus ?? "",
           }));
 
-          const { uphill, downward } = buildUphillDownwardArrays({
-            arrivals,
-            limitPerDirection,
-          });
+          const { uphill, downward } = buildUphillDownwardArrays({ arrivals });
 
           const payload: GetSubwayArrivalResponse = {
             station,


### PR DESCRIPTION
## 작업내용

<!--
해당 Pull Request에서 진행했던 내용들을 작성합니다.

ex)
- [x] 카카오 로그인
- [x] 구글 로그인
 -->

전철 탭에서 사용할 시간표 조회 API를 구현했습니다.

## 스크린샷(선택)

<!--
구현한 내용에 대한 스크린샷을 첨부합니다.
 -->

## 메모(선택)

 <!--
해당 Pull Request에 대한 메모를 작성합니다.

ex)
- 추후 디벨롭 예정입니다.
 -->

## 연관 이슈

<!--
진행했던 이슈의 번호를 입력합니다.

ex)
resolved #1
-->

resolved #38 
