### PR TITLE
[fix] 서버에서 미국 시간으로 인식되는 현상 해결

### DIFF
--- a/src/routes/api/subway/timetable.ts
+++ b/src/routes/api/subway/timetable.ts
@@ -284,6 +284,14 @@ async function getTrainSchedulesByDirections(input: {
   return trainScheduleGroups.flat();
 }
 
+function getKoreanDate() {
+  return new Date(
+    new Date().toLocaleString("en-US", {
+      timeZone: "Asia/Seoul",
+    })
+  );
+}
+
 export const Route = createFileRoute("/api/subway/timetable")({
   server: {
     handlers: {
@@ -305,7 +313,7 @@ export const Route = createFileRoute("/api/subway/timetable")({
             return withErrorResponse("SUBWAY_TIMETABLE_KEY 환경변수가 필요합니다.", 500);
           }
 
-          const now = new Date();
+          const now = getKoreanDate();
           const weekdayName = resolveWeekdayName(now);
           const searchDateTime = formatLocalDateTime(now);
 


### PR DESCRIPTION
## 작업내용

<!--
해당 Pull Request에서 진행했던 내용들을 작성합니다.

ex)
- [x] 카카오 로그인
- [x] 구글 로그인
 -->

서버에서 new Date가 미국 시간으로 나와서 지하철 시간표가 이상하게 나오는 현상을 해결했습니다. 

## 스크린샷(선택)

<!--
구현한 내용에 대한 스크린샷을 첨부합니다.
 -->

## 메모(선택)

 <!--
해당 Pull Request에 대한 메모를 작성합니다.

ex)
- 추후 디벨롭 예정입니다.
 -->

## 연관 이슈

<!--
진행했던 이슈의 번호를 입력합니다.

ex)
resolved #1
-->

resolved #61